### PR TITLE
Add Google repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
         maven { url "https://jitpack.io" }
     }
 }


### PR DESCRIPTION
Hello,

This patch fixes the following error I got during build:
```
Execution failed for task ':app:lintVitalRelease'.
> Could not resolve all files for configuration ':app:lintClassPath'.
   > Could not find com.android.tools.lint:lint-gradle:26.1.0.
     Searched in the following locations:
         file:/home/pierre/lib/android-sdk/extras/m2repository/com/android/tools/lint/lint-gradle/26.1.0/lint-gradle-26.1.0.pom
         file:/home/pierre/lib/android-sdk/extras/m2repository/com/android/tools/lint/lint-gradle/26.1.0/lint-gradle-26.1.0.jar
         file:/home/pierre/lib/android-sdk/extras/google/m2repository/com/android/tools/lint/lint-gradle/26.1.0/lint-gradle-26.1.0.pom
         file:/home/pierre/lib/android-sdk/extras/google/m2repository/com/android/tools/lint/lint-gradle/26.1.0/lint-gradle-26.1.0.jar
         file:/home/pierre/lib/android-sdk/extras/android/m2repository/com/android/tools/lint/lint-gradle/26.1.0/lint-gradle-26.1.0.pom
         file:/home/pierre/lib/android-sdk/extras/android/m2repository/com/android/tools/lint/lint-gradle/26.1.0/lint-gradle-26.1.0.jar
         https://jcenter.bintray.com/com/android/tools/lint/lint-gradle/26.1.0/lint-gradle-26.1.0.pom
         https://jcenter.bintray.com/com/android/tools/lint/lint-gradle/26.1.0/lint-gradle-26.1.0.jar
         https://jitpack.io/com/android/tools/lint/lint-gradle/26.1.0/lint-gradle-26.1.0.pom
         https://jitpack.io/com/android/tools/lint/lint-gradle/26.1.0/lint-gradle-26.1.0.jar
     Required by:
         project :app
```